### PR TITLE
Set readline compilation for Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,15 @@ SRCS	= main.c
 
 OBJS	= $(SRCS:.c=.o)
 
-CFLAGS	= -Wall -Wextra -Werror -g
+CFLAGS	= -Wall -Wextra -Werror
 
-CC		= gcc
+CC		= cc
 
 $(NAME)	: $(OBJS) minishell.h
-	$(CC) $(CFLAGS) $(OBJS) -lreadline -o $(NAME)
+	$(CC) $(CFLAGS) $(OBJS) -L/Users/$(USER)/.brew/Cellar/readline/8.2.1/lib -lreadline -o $(NAME)
 
 %.o		: %.c
-	$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -I/Users/$(USER)/.brew/Cellar/readline/8.2.1/include -o $@
 
 all		: $(NAME)
 

--- a/minishell.h
+++ b/minishell.h
@@ -6,18 +6,20 @@
 /*   By: almelo <almelo@student.42.fr>              +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/02/01 23:23:55 by almelo            #+#    #+#             */
-/*   Updated: 2023/02/05 23:47:29 by almelo           ###   ########.fr       */
+/*   Updated: 2023/02/06 13:44:03 by almelo           ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef MINISHELL_H
 # define MINISHELL_H
 
-# include <readline/readline.h>
-# include <readline/history.h>
 # include <stdlib.h>
 # include <unistd.h>
+
+# include <stdio.h>
+# include <readline/readline.h>
+# include <readline/history.h>
+
 # include <signal.h>
-# include <sys/ioctl.h>
 
 #endif


### PR DESCRIPTION
I had to use -I and -L flags to link with the correct readline version on Mac.